### PR TITLE
:sparkles: email authentication add

### DIFF
--- a/articles/admin.py
+++ b/articles/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
-admin.site.register(Articles)
 from articles.models import Comment,Articles,Category,InSubCategory,OutSubCategory
+
 
 admin.site.register(Comment)
 admin.site.register(Articles)

--- a/articles/apps.py
+++ b/articles/apps.py
@@ -4,6 +4,3 @@ from django.apps import AppConfig
 class ArticlesConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'articles'
-
-    def ready(self):
-        import articles.signals

--- a/articles/models.py
+++ b/articles/models.py
@@ -83,10 +83,9 @@ class Articles(commonModel):
 
 @receiver(pre_save, sender=Articles)
 def update_complete_at(sender, instance, **kwargs):
-  """ check_status값이 True값으로 전환될때 해당 시간을 저장함 """
+    """ check_status값이 True값으로 전환될때 해당 시간을 저장함 """
     if instance.check_status:
         instance.complete_at = timezone.now()
-
 
 class Comment(commonModel):
     user = models.ForeignKey(User, on_delete=models.CASCADE)

--- a/project_ooo/settings.py
+++ b/project_ooo/settings.py
@@ -211,6 +211,30 @@ REST_AUTH = {
     'JWT_TOKEN_CLAIMS_SERIALIZER': 'users.serializers.CustomTokenObtainPairSerializer', # 토큰 페이로드 재정의
     'JWT_AUTH_HTTPONLY':False # refresh 토큰 생성
 }
-ACCOUNT_EMAIL_VERIFICATION = 'none' # 이메일 인증 구현시 변경 필요
 REST_USE_JWT = True
 SITE_ID = 1
+
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = 'smtp.gmail.com' # 메일 호스트 서버
+EMAIL_PORT = '587' # gmail과 통신하는 포트
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER") # 발신할 이메일
+EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD") # 발신할 메일의 비밀번호
+EMAIL_USE_TLS = True # TLS 보안 방법
+DEFAULT_FROM_EMAIL = EMAIL_HOST_USER # 사이트와 관련한 자동응답을 받을 이메일 주소
+URL_FRONT = 'http://****' # 공개적인 웹페이지가 있다면 등록
+
+ACCOUNT_CONFIRM_EMAIL_ON_GET = True # 유저가 받은 링크를 클릭하면 회원가입 완료되게끔
+
+EMAIL_CONFIRMATION_AUTHENTICATED_REDIRECT_URL = '/' # 사이트와 관련한 자동응답을 받을 이메일 주소,'webmaster@localhost'
+ACCOUNT_EMAIL_REQUIRED = True
+ACCOUNT_EMAIL_VERIFICATION = "mandatory"
+ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = 1
+ACCOUNT_EMAIL_SUBJECT_PREFIX = '[오운완 이메일 인증]' #이메일 제목앞에 붙일내용
+
+THENTICATION_BACKENDS = [
+    # Needed to login by username in Django admin, regardless of `allauth`
+    'django.contrib.auth.backends.ModelBackend',
+
+    # `allauth` specific authentication methods, such as login by e-mail
+    'allauth.account.auth_backends.AuthenticationBackend',
+]

--- a/project_ooo/urls.py
+++ b/project_ooo/urls.py
@@ -23,5 +23,6 @@ urlpatterns = [
     # dj-rest-auth 
     path('users/', include('users.urls')),
     # allauth(외부인증)
-    # path('users/', include('allauth.urls')),
+    path("", include("allauth.account.urls")),
+    path('users/', include('allauth.urls')),
 ]

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,13 +1,19 @@
-from django.urls import path, include
+from django.urls import path, include, re_path
 from rest_framework_simplejwt.views import (
     TokenObtainPairView,
     TokenRefreshView,
 )
 from users import views
+from dj_rest_auth.registration.views import VerifyEmailView
 
 urlpatterns = [
     path('dj-rest-auth/', include('dj_rest_auth.urls')),
     path('dj-rest-auth/registration/', include('dj_rest_auth.registration.urls')),
+    
+    # 유효한 이메일이 유저에게 전달
+    re_path(r'^account-confirm-email/$', VerifyEmailView.as_view(), name='account_email_verification_sent'),
+    # 유저가 클릭한 이메일(=링크) 확인
+    re_path(r'^account-confirm-email/(?P<key>[-:\w]+)/$', views.ConfirmEmailView.as_view(), name='account_confirm_email'),
 ]
 
 # 상세 주소


### PR DESCRIPTION
회원가입을 할때 작성한 이메일로 이메일 인증 메일이 발송

(postman로 테스트 완료)

(추가사항)
발송 이메일의 구성 변경, 로고 추가
발송 이메일의 인증 url 연결
