### PR TITLE
:ambulance:article model subcategory fix

### DIFF
--- a/articles/models.py
+++ b/articles/models.py
@@ -41,24 +41,23 @@ class InSubCategory(models.Model):
 
 class OutSubCategory(models.Model):
     out_sub_categories = (
-        ('걷기', '실외 걷기'),
-        ('뛰기', '야외 런닝'),
-        ('자전거', '야외 싸이클'),
-        ('구기', '구기종목'),
+        ('실외 걷기', '실외 걷기'),
+        ('야외 런닝', '야외 런닝'),
+        ('야외 싸이클', '야외 싸이클'),
+        ('구기종목', '구기종목'),
     )
     out_sub_category = models.CharField("상세 운동종류",max_length=10,choices=out_sub_categories)
 
     
     def __str__(self):
-        return self.get_out_sub_category_display()
-
+        return self.out_sub_category
 
 class Articles(CommonModel):
     # class Meta:
     #     db_table = "Article"
 
     user = models.ForeignKey(User, on_delete=models.CASCADE)
-    content = models.TextField("글내용")
+    content = models.TextField("글내용", max_length=15)
     select_day = models.DateField()
     check_status = models.BooleanField(default=False)
     is_private = models.BooleanField(default=False)
@@ -75,7 +74,7 @@ class Articles(CommonModel):
     # likes = models.ManyToManyField(User, blank=True, related_name="like_articles", through='Feed_like') 개인 프로필에서 보이는 좋아요 한 글
     
     def __str__(self):
-        return str(self.category)
+        return str(self.content)
 
 
 class Comment(CommonModel):

--- a/articles/views.py
+++ b/articles/views.py
@@ -46,6 +46,7 @@ class ArticlesViews(APIView):
 
     def post(self, request):
         serializer = ArticlesCreateSerializer(data=request.data)
+        print(request.data)
         if serializer.is_valid():
             serializer.save(user=request.user)
             return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -85,7 +86,7 @@ class ArticlesDetailView(APIView):
 
 
     def delete(self, request, article_id):
-        articles = Articles.objects.get(id=article_id)
+        articles = get_object_or_404(Articles, id=article_id)
         if request.user == articles.user:
             articles.delete()
             return Response({"message": "삭제완료!"},status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
* 수정사항 및 테스트 완료
1. article post 및 put 요청시 in_subcategory와 out_subcategory의 key값이 같아 잘못 가져오는 현상 발견
-> out_subcategory의 key값 변경
2. admin의 category str: value값으로 보이는 현상 수정
3. article content max length 설정
4. 튜터님께 피드백받았던 get_object_or_404 가 delete에 없는 부분 확인, 해당 내용 수정
-> feed와 달력에 보이는 article 값은 get으로 가져오면 값이 하나밖에 안가져와져서 filter써야함 (get_object_or_404사용불가)